### PR TITLE
fix: upgrade brace-expansion to 5.0.7, 1.1.16, 2.1.2 (CVE-2026-13149)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@nextcloud/paths": "^3.1.0",
         "@nextcloud/router": "^3.1.0",
         "@nextcloud/sharing": "^0.4.0",
+        "brace-expansion": "^2.1.2",
         "jszip": "^3.10.1"
       },
       "devDependencies": {
@@ -4536,9 +4537,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@nextcloud/paths": "^3.1.0",
     "@nextcloud/router": "^3.1.0",
     "@nextcloud/sharing": "^0.4.0",
+    "brace-expansion": "^2.1.2",
     "jszip": "^3.10.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary
Upgrade brace-expansion from 2.0.3 to 5.0.7, 1.1.16, 2.1.2 to fix CVE-2026-13149.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-13149 |
| **Severity** | HIGH |
| **Scanner** | trivy |
| **Rule** | `CVE-2026-13149` |
| **File** | `package-lock.json` |
| **Assessment** | Likely exploitable |

**Description**: brace-expansion: Brace-expansion: Denial of Service due to exponential-time complexity

## Evidence

**Scanner confirmation**: trivy rule `CVE-2026-13149` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `package.json`
- `package-lock.json`

## Behavior Preservation
The change is scoped to 2 files on the vulnerable path, and the project's existing tests still pass, so intended behavior is unchanged.

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
