### PR TITLE
docs(agents): sync agent rules with nextcloud/.github#774

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,14 @@ All contributions generated or assisted by this agent must fully comply with:
 - Ensure every pull request includes a disclosure of AI tool use in the PR description.
 - Produce focused, scoped pull requests that address exactly one concern. Do not touch unrelated files or introduce incidental refactors.
 - Verify all dependencies against actual package registries before suggesting them. Do not use hallucinated or unverified package names.
+- Write code comments that document the code, never the process that produced it:
+  - Comments describe what the code does - method signatures, behavior, and constraints the code itself cannot express (e.g. a non-obvious invariant or workaround).
+  - Never add comments that document progress, decisions, or changes (e.g. "changed X to Y", "as requested", "this fixes ...", "previously this did ..."). That belongs in the commit message or PR discussion; in the code it goes stale and becomes misleading.
+  - Do not narrate self-explanatory code. If the code is readable without a comment, omit the comment.
+  - Keep comments brief - short and simple, matching the comment density of the surrounding code.
+- Reuse existing helper functions and utilities instead of re-implementing their logic inline. When fixing a flawed pattern, fix every occurrence of it across the changed code, not only the instance that was pointed out.
+- Run permission and access-control checks before the operation they guard, never after it and never only in the UI layer.
+- When adding or changing user-facing functionality, wire it up in every context where the affected component is used - the default authenticated view, public share pages, and embedded contexts such as the Smart Picker and reference widgets. When emitting new events, verify that every consumer of the component subscribes to and handles them.
 - Explicitly inform the contributor when any action they are about to take, or have taken, would violate the AI Contribution Policy or the Contribution Guidelines. Do not silently proceed. State which rule is at risk and what the contributor should do instead.
 - Warn the contributor if a pull request is growing too large. A PR approaching several thousand lines of changed code is a signal that it should be split into smaller, focused PRs. Suggest a logical split before the PR is opened, not after.
 - Recommend opening a ticket for discussion before starting implementation whenever a feature or change is sufficiently complex - for example when it touches multiple subsystems, requires architectural decisions, or the right approach is not yet clear. A ticket allows maintainers and the contributor to align on direction before code is written, avoiding wasted effort on a PR that may be rejected or require fundamental rework.
@@ -33,7 +41,7 @@ All contributions generated or assisted by this agent must fully comply with:
 - Generate or submit security reports without independent human verification. Report verified vulnerabilities via [HackerOne](https://hackerone.com/nextcloud), not as GitHub issues.
 - Write PR descriptions, review comments, or issue reports on behalf of the contributor. These must be in the contributor's own words.
 - Fully automate the resolution of issues labeled [`good first issue`](https://github.com/issues?q=org%3Anextcloud+label%3A%22good+first+issue%22) or similar beginner-friendly labels.
-- Submit code that has not been reviewed and cleaned up by the contributor. Dead code, redundant logic, excessive comments, and unrelated changes must be removed before submission.
+- Submit code that has not been reviewed and cleaned up by the contributor. Dead code, redundant logic, excessive comments, malformed or garbled characters (e.g. `�` replacement characters), and unrelated changes must be removed before submission.
 
 ---
 


### PR DESCRIPTION
Incorporate the updated AGENT_MD_SNIPPETS.md into AGENTS.md:

- Code comments must document the code, never the process that produced it
- Reuse existing helpers and fix every occurrence of a flawed pattern
- Run permission and access-control checks before the guarded operation
- Wire up user-facing changes in every reachable context (public shares, Smart Picker, reference widgets)
- Remove malformed or garbled characters before submission

Assisted-by: Claude Code:claude-fable-5



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
